### PR TITLE
Fix improper use of non-polling Eventually in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### New
 
 - **CloudEventSource**: Introduce ClusterCloudEventSource ([#3533](https://github.com/kedacore/keda/issues/3533))
+- **General**: Fix admission webhook validation not denying invalid fallbacks and replica counts ([#5954](https://github.com/kedacore/keda/issues/5954))
 
 #### Experimental
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,6 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### New
 
 - **CloudEventSource**: Introduce ClusterCloudEventSource ([#3533](https://github.com/kedacore/keda/issues/3533))
-- **General**: Fix admission webhook validation not denying invalid fallbacks and replica counts ([#5954](https://github.com/kedacore/keda/issues/5954))
 
 #### Experimental
 
@@ -72,7 +71,7 @@ Here is an overview of all new **experimental** features:
 
 ### Fixes
 
-- TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
+- **General**: Fix admission webhook validation not denying invalid fallbacks and replica counts ([#5954](https://github.com/kedacore/keda/issues/5954))
 
 ### Deprecations
 

--- a/apis/eventing/v1alpha1/cloudeventsource_webhook_test.go
+++ b/apis/eventing/v1alpha1/cloudeventsource_webhook_test.go
@@ -145,15 +145,13 @@ var _ = It("validate cloudeventsource when event type is not support", func() {
 
 	spec := createCloudEventSourceSpecWithExcludeEventType("keda.scaledobject.ready.v1.test")
 	ces := createCloudEventSource("nsccesexcludenotsupport", namespaceName, spec)
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), ces)
-	}).Should(HaveOccurred())
+	err = k8sClient.Create(context.Background(), ces)
+	Expect(err).To(HaveOccurred())
 
 	spec = createCloudEventSourceSpecWithIncludeEventType("keda.scaledobject.ready.v1.test")
 	ces = createCloudEventSource("nsccesincludenotsupport", namespaceName, spec)
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), ces)
-	}).Should(HaveOccurred())
+	err = k8sClient.Create(context.Background(), ces)
+	Expect(err).To(HaveOccurred())
 })
 
 var _ = It("validate cloudeventsource when event type is support", func() {
@@ -165,17 +163,15 @@ var _ = It("validate cloudeventsource when event type is support", func() {
 	for k, eventType := range AllEventTypes {
 		spec := createCloudEventSourceSpecWithExcludeEventType(eventType)
 		ces := createCloudEventSource("cloudeventexclude"+strconv.Itoa(k), namespaceName, spec)
-		Eventually(func() error {
-			return k8sClient.Create(context.Background(), ces)
-		}).ShouldNot(HaveOccurred())
+		err = k8sClient.Create(context.Background(), ces)
+		Expect(err).ToNot(HaveOccurred())
 	}
 
 	for k, eventType := range AllEventTypes {
 		spec := createCloudEventSourceSpecWithIncludeEventType(eventType)
 		ces := createCloudEventSource("cloudeventinclude"+strconv.Itoa(k), namespaceName, spec)
-		Eventually(func() error {
-			return k8sClient.Create(context.Background(), ces)
-		}).ShouldNot(HaveOccurred())
+		err = k8sClient.Create(context.Background(), ces)
+		Expect(err).ToNot(HaveOccurred())
 	}
 })
 
@@ -187,9 +183,8 @@ var _ = It("validate invalid cloudeventsource which eventtype in both excludetyp
 
 	spec := createInvalidCloudEventSourceSpe(ScaledObjectReadyType)
 	ces := createCloudEventSource("invalidcloudevent", namespaceName, spec)
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), ces)
-	}).Should(HaveOccurred())
+	err = k8sClient.Create(context.Background(), ces)
+	Expect(err).To(HaveOccurred())
 })
 
 // -------------------------------------------------------------------------- //

--- a/apis/keda/v1alpha1/scaledjob_webhook_test.go
+++ b/apis/keda/v1alpha1/scaledjob_webhook_test.go
@@ -36,9 +36,8 @@ var _ = It("should validate empty triggers in ScaledJob", func() {
 
 	sj := createScaledJob(sjName, namespaceName, []ScaleTriggers{})
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), sj)
-	}).Should(HaveOccurred())
+	err = k8sClient.Create(context.Background(), sj)
+	Expect(err).To(HaveOccurred())
 })
 
 // -------------------------------------------------------------------------- //

--- a/apis/keda/v1alpha1/scaledobject_types.go
+++ b/apis/keda/v1alpha1/scaledobject_types.go
@@ -284,7 +284,7 @@ func CheckFallbackValid(scaledObject *ScaledObject) error {
 
 	for _, trigger := range scaledObject.Spec.Triggers {
 		if trigger.Type == cpuString || trigger.Type == memoryString {
-			return fmt.Errorf("type is %s , but fallback it is not supported by the CPU & memory scalers", trigger.Type)
+			return fmt.Errorf("type is %s, but fallback it is not supported by the CPU & memory scalers", trigger.Type)
 		}
 		if trigger.MetricType != autoscalingv2.AverageValueMetricType {
 			return fmt.Errorf("MetricType=%s, but Fallback can only be enabled for triggers with metric of type AverageValue", trigger.MetricType)

--- a/apis/keda/v1alpha1/scaledobject_webhook.go
+++ b/apis/keda/v1alpha1/scaledobject_webhook.go
@@ -165,6 +165,7 @@ func verifyReplicaCount(incomingSo *ScaledObject, action string, _ bool) error {
 	if err != nil {
 		scaledobjectlog.WithValues("name", incomingSo.Name).Error(err, "validation error")
 		metricscollector.RecordScaledObjectValidatingErrors(incomingSo.Namespace, action, "incorrect-replicas")
+		return err
 	}
 	return nil
 }
@@ -174,6 +175,7 @@ func verifyFallback(incomingSo *ScaledObject, action string, _ bool) error {
 	if err != nil {
 		scaledobjectlog.WithValues("name", incomingSo.Name).Error(err, "validation error")
 		metricscollector.RecordScaledObjectValidatingErrors(incomingSo.Namespace, action, "incorrect-fallback")
+		return err
 	}
 	return nil
 }

--- a/apis/keda/v1alpha1/scaledobject_webhook_test.go
+++ b/apis/keda/v1alpha1/scaledobject_webhook_test.go
@@ -18,8 +18,6 @@ package v1alpha1
 
 import (
 	"context"
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -41,9 +39,8 @@ var _ = It("should validate the so creation when there isn't any hpa", func() {
 	err := k8sClient.Create(context.Background(), namespace)
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("should validate the so creation when there are other SO for other workloads", func() {
@@ -59,9 +56,8 @@ var _ = It("should validate the so creation when there are other SO for other wo
 	err = k8sClient.Create(context.Background(), so1)
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so2)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so2)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("should validate the so creation when there are other HPA for other workloads", func() {
@@ -77,9 +73,8 @@ var _ = It("should validate the so creation when there are other HPA for other w
 	err = k8sClient.Create(context.Background(), hpa)
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("should validate the so creation when it's own hpa is already generated", func() {
@@ -96,9 +91,8 @@ var _ = It("should validate the so creation when it's own hpa is already generat
 	err = k8sClient.Create(context.Background(), hpa)
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("should validate the so update when it's own hpa is already generated", func() {
@@ -119,9 +113,9 @@ var _ = It("should validate the so update when it's own hpa is already generated
 	Expect(err).ToNot(HaveOccurred())
 
 	so.Spec.MaxReplicaCount = ptr.To[int32](7)
-	Eventually(func() error {
-		return k8sClient.Update(context.Background(), so)
-	}).ShouldNot(HaveOccurred())
+
+	err = k8sClient.Update(context.Background(), so)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("shouldn't validate the so creation when there is another unmanaged hpa", func() {
@@ -138,9 +132,8 @@ var _ = It("shouldn't validate the so creation when there is another unmanaged h
 	err = k8sClient.Create(context.Background(), hpa)
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).Should(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).To(HaveOccurred())
 })
 
 var _ = It("shouldn't validate the so creation when the replica counts are wrong", func() {
@@ -207,9 +200,8 @@ var _ = It("shouldn't validate the so creation when there is another unmanaged h
 	err = k8sClient.Create(context.Background(), hpa)
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("shouldn't validate the so creation when hpa has shared-ownership unactivated", func() {
@@ -227,9 +219,8 @@ var _ = It("shouldn't validate the so creation when hpa has shared-ownership una
 	err = k8sClient.Create(context.Background(), hpa)
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("shouldn't validate the so creation when there is another so", func() {
@@ -246,9 +237,8 @@ var _ = It("shouldn't validate the so creation when there is another so", func()
 	err = k8sClient.Create(context.Background(), so2)
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).Should(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).To(HaveOccurred())
 })
 
 var _ = It("shouldn't validate the so creation when there is another hpa with custom apis", func() {
@@ -265,9 +255,8 @@ var _ = It("shouldn't validate the so creation when there is another hpa with cu
 	err = k8sClient.Create(context.Background(), hpa)
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).Should(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).To(HaveOccurred())
 })
 
 var _ = It("should validate the so creation with cpu and memory when deployment has requests", func() {
@@ -283,9 +272,8 @@ var _ = It("should validate the so creation with cpu and memory when deployment 
 	err = k8sClient.Create(context.Background(), workload)
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("shouldn't validate the creation with cpu and memory when deployment is missing", func() {
@@ -297,9 +285,8 @@ var _ = It("shouldn't validate the creation with cpu and memory when deployment 
 	err := k8sClient.Create(context.Background(), namespace)
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).Should(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).To(HaveOccurred())
 })
 
 var _ = It("should validate the creation with cpu and memory when deployment is missing and dry-run is true", func() {
@@ -311,9 +298,8 @@ var _ = It("should validate the creation with cpu and memory when deployment is 
 	err := k8sClient.Create(context.Background(), namespace)
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so, client.DryRunAll)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so, client.DryRunAll)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("shouldn't validate the so creation with cpu and memory when deployment hasn't got memory request", func() {
@@ -329,9 +315,8 @@ var _ = It("shouldn't validate the so creation with cpu and memory when deployme
 	err = k8sClient.Create(context.Background(), workload)
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).Should(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).To(HaveOccurred())
 })
 
 // This test checks whether the validation fails when the CPU and memory resource limits are missing in pod spec (in
@@ -351,10 +336,9 @@ var _ = It("shouldn't validate the SO creation with CPU and memory when deployme
 	err = k8sClient.Create(context.Background(), deployment)
 	Expect(err).ToNot(HaveOccurred())
 
-	// Create scaled object, asynchronously
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), scaledObject)
-	}).Should(HaveOccurred())
+	// Create scaled object
+	err = k8sClient.Create(context.Background(), scaledObject)
+	Expect(err).To(HaveOccurred())
 })
 
 // This test checks whether the validation fails when the CPU and memory resource limits are missing in pod spec (in
@@ -383,10 +367,9 @@ var _ = It("should validate the SO creation with CPU and memory when deployment 
 	err = k8sClient.Create(context.Background(), deployment)
 	Expect(err).ToNot(HaveOccurred())
 
-	// Create scaled object, asynchronously
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), scaledObject)
-	}).ShouldNot(HaveOccurred())
+	// Create scaled object
+	err = k8sClient.Create(context.Background(), scaledObject)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("shouldn't validate the so creation with cpu and memory when deployment hasn't got cpu request", func() {
@@ -402,9 +385,8 @@ var _ = It("shouldn't validate the so creation with cpu and memory when deployme
 	err = k8sClient.Create(context.Background(), workload)
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).Should(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).To(HaveOccurred())
 })
 
 var _ = It("should validate the so creation with cpu and memory when statefulset has requests", func() {
@@ -420,9 +402,8 @@ var _ = It("should validate the so creation with cpu and memory when statefulset
 	err = k8sClient.Create(context.Background(), workload)
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("shouldn't validate the so creation with cpu and memory when statefulset hasn't got memory request", func() {
@@ -438,9 +419,8 @@ var _ = It("shouldn't validate the so creation with cpu and memory when stateful
 	err = k8sClient.Create(context.Background(), workload)
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).Should(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).To(HaveOccurred())
 })
 
 var _ = It("shouldn't validate the so creation with cpu and memory when statefulset hasn't got cpu request", func() {
@@ -456,9 +436,8 @@ var _ = It("shouldn't validate the so creation with cpu and memory when stateful
 	err = k8sClient.Create(context.Background(), workload)
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).Should(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).To(HaveOccurred())
 })
 
 var _ = It("should validate the so creation without cpu and memory when custom resources", func() {
@@ -470,9 +449,8 @@ var _ = It("should validate the so creation without cpu and memory when custom r
 	err := k8sClient.Create(context.Background(), namespace)
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("should validate so creation when all requirements are met for scaling to zero with cpu scaler", func() {
@@ -488,9 +466,8 @@ var _ = It("should validate so creation when all requirements are met for scalin
 	err = k8sClient.Create(context.Background(), workload)
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("shouldn't validate so creation with cpu scaler requirements not being met for scaling to 0", func() {
@@ -502,11 +479,12 @@ var _ = It("shouldn't validate so creation with cpu scaler requirements not bein
 
 	err := k8sClient.Create(context.Background(), namespace)
 	Expect(err).ToNot(HaveOccurred())
+
 	err = k8sClient.Create(context.Background(), workload)
 	Expect(err).ToNot(HaveOccurred())
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).Should(HaveOccurred())
+
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).To(HaveOccurred())
 })
 
 var _ = It("should validate so creation when min replicas is > 0 with only cpu scaler given", func() {
@@ -518,11 +496,12 @@ var _ = It("should validate so creation when min replicas is > 0 with only cpu s
 
 	err := k8sClient.Create(context.Background(), namespace)
 	Expect(err).ToNot(HaveOccurred())
+
 	err = k8sClient.Create(context.Background(), workload)
 	Expect(err).ToNot(HaveOccurred())
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).ShouldNot(HaveOccurred())
+
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).ToNot(HaveOccurred())
 
 })
 
@@ -552,9 +531,8 @@ var _ = It("should not validate ScaledObject creation when deployment only provi
 		},
 	}
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("should not validate ScaledObject creation when deployment only provides memory resource limits", func() {
@@ -583,9 +561,8 @@ var _ = It("should not validate ScaledObject creation when deployment only provi
 		},
 	}
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("should validate the so update if it's removing the finalizer even if it's invalid", func() {
@@ -602,40 +579,16 @@ var _ = It("should validate the so update if it's removing the finalizer even if
 	err = k8sClient.Create(context.Background(), workload)
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).ToNot(HaveOccurred())
 
 	workload.Spec.Template.Spec.Containers[0].Resources.Requests = nil
 	err = k8sClient.Update(context.Background(), workload)
 	Expect(err).ToNot(HaveOccurred())
 
 	so.ObjectMeta.Finalizers = []string{}
-	Eventually(func() error {
-		return k8sClient.Update(context.Background(), so)
-	}).ShouldNot(HaveOccurred())
-})
-
-var _ = It("shouldn't create so when stabilizationWindowSeconds exceeds 3600", func() {
-
-	namespaceName := "fail-so-creation"
-	namespace := createNamespace(namespaceName)
-	so := createScaledObject(soName, namespaceName, workloadName, "apps/v1", "Deployment", false, map[string]string{}, "")
-	so.Spec.Advanced.HorizontalPodAutoscalerConfig = &HorizontalPodAutoscalerConfig{
-		Behavior: &v2.HorizontalPodAutoscalerBehavior{
-			ScaleDown: &v2.HPAScalingRules{
-				StabilizationWindowSeconds: ptr.To[int32](3700),
-			},
-		},
-	}
-	err := k8sClient.Create(context.Background(), namespace)
+	err = k8sClient.Update(context.Background(), so)
 	Expect(err).ToNot(HaveOccurred())
-
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).
-		WithTimeout(5 * time.Second).
-		Should(HaveOccurred())
 })
 
 var _ = It("should validate empty triggers in ScaledObject", func() {
@@ -657,9 +610,8 @@ var _ = It("should validate empty triggers in ScaledObject", func() {
 	so := createScaledObject(soName, namespaceName, workloadName, "apps/v1", "Deployment", false, map[string]string{}, "")
 	so.Spec.Triggers = []ScaleTriggers{}
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).Should(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).To(HaveOccurred())
 })
 
 // ============================ SCALING MODIFIERS ============================ \\
@@ -699,9 +651,8 @@ var _ = It("should validate the so creation with ScalingModifiers.Formula", func
 	Expect(err).ToNot(HaveOccurred())
 	err = k8sClient.Create(context.Background(), workload)
 	Expect(err).ToNot(HaveOccurred())
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("shouldnt validate the so creation with scalingModifiers.Formula but no target", func() {
@@ -738,9 +689,8 @@ var _ = It("shouldnt validate the so creation with scalingModifiers.Formula but 
 	Expect(err).ToNot(HaveOccurred())
 	err = k8sClient.Create(context.Background(), workload)
 	Expect(err).ToNot(HaveOccurred())
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).Should(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).To(HaveOccurred())
 })
 
 var _ = It("shouldnt validate the so creation with ScalingModifiers when triggers dont have names", func() {
@@ -775,9 +725,8 @@ var _ = It("shouldnt validate the so creation with ScalingModifiers when trigger
 	Expect(err).ToNot(HaveOccurred())
 	err = k8sClient.Create(context.Background(), workload)
 	Expect(err).ToNot(HaveOccurred())
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).Should(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).To(HaveOccurred())
 })
 
 var _ = It("should validate the so creation with ScalingModifiers when formula triggers do have names but not all triggers", func() {
@@ -813,9 +762,8 @@ var _ = It("should validate the so creation with ScalingModifiers when formula t
 	Expect(err).ToNot(HaveOccurred())
 	err = k8sClient.Create(context.Background(), workload)
 	Expect(err).ToNot(HaveOccurred())
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("should validate the so creation with ScalingModifiers when formula casts to float already", func() {
@@ -842,9 +790,8 @@ var _ = It("should validate the so creation with ScalingModifiers when formula c
 	Expect(err).ToNot(HaveOccurred())
 	err = k8sClient.Create(context.Background(), workload)
 	Expect(err).ToNot(HaveOccurred())
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("should validate the so creation with ScalingModifiers.Formula - casting float from ternary operator", func() {
@@ -881,9 +828,8 @@ var _ = It("should validate the so creation with ScalingModifiers.Formula - cast
 	Expect(err).ToNot(HaveOccurred())
 	err = k8sClient.Create(context.Background(), workload)
 	Expect(err).ToNot(HaveOccurred())
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 // this test checks that internally, the casting to float happened successfully
@@ -924,9 +870,8 @@ var _ = It("should validate the so creation with ScalingModifiers.Formula - tern
 	Expect(err).ToNot(HaveOccurred())
 	err = k8sClient.Create(context.Background(), workload)
 	Expect(err).ToNot(HaveOccurred())
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("should validate the so creation with ScalingModifiers.Formula - count operator", func() {
@@ -963,9 +908,8 @@ var _ = It("should validate the so creation with ScalingModifiers.Formula - coun
 	Expect(err).ToNot(HaveOccurred())
 	err = k8sClient.Create(context.Background(), workload)
 	Expect(err).ToNot(HaveOccurred())
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("should validate the so creation with ScalingModifiers.Formula - complex ternary", func() {
@@ -1002,9 +946,8 @@ var _ = It("should validate the so creation with ScalingModifiers.Formula - comp
 	Expect(err).ToNot(HaveOccurred())
 	err = k8sClient.Create(context.Background(), workload)
 	Expect(err).ToNot(HaveOccurred())
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("should validate the so creation with ScalingModifiers.Formula - double float cast", func() {
@@ -1040,9 +983,8 @@ var _ = It("should validate the so creation with ScalingModifiers.Formula - doub
 	Expect(err).ToNot(HaveOccurred())
 	err = k8sClient.Create(context.Background(), workload)
 	Expect(err).ToNot(HaveOccurred())
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = AfterSuite(func() {

--- a/apis/keda/v1alpha1/scaledobject_webhook_test.go
+++ b/apis/keda/v1alpha1/scaledobject_webhook_test.go
@@ -153,9 +153,8 @@ var _ = It("shouldn't validate the so creation when the replica counts are wrong
 	err := k8sClient.Create(context.Background(), namespace)
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).Should(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).To(HaveOccurred())
 })
 
 var _ = It("shouldn't validate the so creation when the fallback is wrong", func() {
@@ -171,9 +170,8 @@ var _ = It("shouldn't validate the so creation when the fallback is wrong", func
 	err := k8sClient.Create(context.Background(), namespace)
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).Should(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).To(HaveOccurred())
 })
 
 var _ = It("shouldn't validate the so creation When the fallback are configured and the scaler is either CPU or memory.", func() {
@@ -191,9 +189,8 @@ var _ = It("shouldn't validate the so creation When the fallback are configured 
 	err = k8sClient.Create(context.Background(), workload)
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), so)
-	}).Should(HaveOccurred())
+	err = k8sClient.Create(context.Background(), so)
+	Expect(err).To(HaveOccurred())
 })
 
 var _ = It("shouldn't validate the so creation when there is another unmanaged hpa and so has transfer-hpa-ownership activated", func() {

--- a/apis/keda/v1alpha1/triggerauthentication_webhook_test.go
+++ b/apis/keda/v1alpha1/triggerauthentication_webhook_test.go
@@ -34,9 +34,8 @@ var _ = It("validate triggerauthentication when IdentityTenantID is not nil and 
 	identityTenantID := "12345"
 	spec := createTriggerAuthenticationSpecWithPodIdentity(PodIdentityProviderAzureWorkload, nil, &identityID, &identityTenantID, nil, nil)
 	ta := createTriggerAuthentication("identitytenantidta", namespaceName, "TriggerAuthentication", spec)
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), ta)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), ta)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("validate triggerauthentication when IdentityTenantID is not nil but empty", func() {
@@ -49,9 +48,8 @@ var _ = It("validate triggerauthentication when IdentityTenantID is not nil but 
 	identityTenantID := ""
 	spec := createTriggerAuthenticationSpecWithPodIdentity(PodIdentityProviderAzureWorkload, nil, &identityID, &identityTenantID, nil, nil)
 	ta := createTriggerAuthentication("emptyidentitytenantidta", namespaceName, "TriggerAuthentication", spec)
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), ta)
-	}).Should(HaveOccurred())
+	err = k8sClient.Create(context.Background(), ta)
+	Expect(err).To(HaveOccurred())
 })
 
 var _ = It("validate triggerauthentication when IdentityAuthorityHost is not nil and not empty and IdentityTenantID is not nil and not empty", func() {
@@ -65,9 +63,8 @@ var _ = It("validate triggerauthentication when IdentityAuthorityHost is not nil
 	identityAuthorityHost := "12345"
 	spec := createTriggerAuthenticationSpecWithPodIdentity(PodIdentityProviderAzureWorkload, nil, &identityID, &identityTenantID, &identityAuthorityHost, nil)
 	ta := createTriggerAuthentication("identityauthorityhostta", namespaceName, "TriggerAuthentication", spec)
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), ta)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), ta)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("validate triggerauthentication when IdentityAuthorityHost is not nil and not empty and IdentityTenantID is nil", func() {
@@ -80,9 +77,8 @@ var _ = It("validate triggerauthentication when IdentityAuthorityHost is not nil
 	identityAuthorityHost := "12345"
 	spec := createTriggerAuthenticationSpecWithPodIdentity(PodIdentityProviderAzureWorkload, nil, &identityID, nil, &identityAuthorityHost, nil)
 	ta := createTriggerAuthentication("niltenantidentityauthorityhostta", namespaceName, "TriggerAuthentication", spec)
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), ta)
-	}).Should(HaveOccurred())
+	err = k8sClient.Create(context.Background(), ta)
+	Expect(err).To(HaveOccurred())
 })
 
 var _ = It("validate triggerauthentication when IdentityAuthorityHost is not nil and not empty and IdentityTenantID is not nil but empty", func() {
@@ -96,9 +92,8 @@ var _ = It("validate triggerauthentication when IdentityAuthorityHost is not nil
 	identityAuthorityHost := "12345"
 	spec := createTriggerAuthenticationSpecWithPodIdentity(PodIdentityProviderAzureWorkload, nil, &identityID, &identityTenantID, &identityAuthorityHost, nil)
 	ta := createTriggerAuthentication("emptytenantidentityauthorityhostta", namespaceName, "TriggerAuthentication", spec)
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), ta)
-	}).Should(HaveOccurred())
+	err = k8sClient.Create(context.Background(), ta)
+	Expect(err).To(HaveOccurred())
 })
 
 var _ = It("validate triggerauthentication when RoleArn is not empty and IdentityOwner is nil", func() {
@@ -110,9 +105,8 @@ var _ = It("validate triggerauthentication when RoleArn is not empty and Identit
 	roleArn := "Hello"
 	spec := createTriggerAuthenticationSpecWithPodIdentity(PodIdentityProviderAws, &roleArn, nil, nil, nil, nil)
 	ta := createTriggerAuthentication("identityidta", namespaceName, "TriggerAuthentication", spec)
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), ta)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), ta)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("validate triggerauthentication when RoleArn is not empty and IdentityOwner is keda", func() {
@@ -125,9 +119,8 @@ var _ = It("validate triggerauthentication when RoleArn is not empty and Identit
 	identityOwner := kedaString
 	spec := createTriggerAuthenticationSpecWithPodIdentity(PodIdentityProviderAws, &roleArn, nil, nil, nil, &identityOwner)
 	ta := createTriggerAuthentication("identityidta", namespaceName, "TriggerAuthentication", spec)
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), ta)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), ta)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("validate triggerauthentication when RoleArn is not empty and IdentityOwner is workload", func() {
@@ -140,9 +133,8 @@ var _ = It("validate triggerauthentication when RoleArn is not empty and Identit
 	identityOwner := workloadString
 	spec := createTriggerAuthenticationSpecWithPodIdentity(PodIdentityProviderAws, &roleArn, nil, nil, nil, &identityOwner)
 	ta := createTriggerAuthentication("identityidta", namespaceName, "TriggerAuthentication", spec)
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), ta)
-	}).Should(HaveOccurred())
+	err = k8sClient.Create(context.Background(), ta)
+	Expect(err).To(HaveOccurred())
 })
 
 var _ = It("validate triggerauthentication when RoleArn is empty and IdentityOwner is keda", func() {
@@ -154,9 +146,8 @@ var _ = It("validate triggerauthentication when RoleArn is empty and IdentityOwn
 	identityOwner := kedaString
 	spec := createTriggerAuthenticationSpecWithPodIdentity(PodIdentityProviderAws, nil, nil, nil, nil, &identityOwner)
 	ta := createTriggerAuthentication("identityidta", namespaceName, "TriggerAuthentication", spec)
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), ta)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), ta)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("validate triggerauthentication when RoleArn is not empty and IdentityOwner is workload", func() {
@@ -168,9 +159,8 @@ var _ = It("validate triggerauthentication when RoleArn is not empty and Identit
 	identityOwner := workloadString
 	spec := createTriggerAuthenticationSpecWithPodIdentity(PodIdentityProviderAws, nil, nil, nil, nil, &identityOwner)
 	ta := createTriggerAuthentication("identityidta", namespaceName, "TriggerAuthentication", spec)
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), ta)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), ta)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("validate clustertriggerauthentication when RoleArn is not empty and IdentityOwner is nil", func() {
@@ -182,9 +172,8 @@ var _ = It("validate clustertriggerauthentication when RoleArn is not empty and 
 	roleArn := "Hello"
 	spec := createTriggerAuthenticationSpecWithPodIdentity(PodIdentityProviderAws, &roleArn, nil, nil, nil, nil)
 	ta := createTriggerAuthentication("clusteridentityidta", namespaceName, "ClusterTriggerAuthentication", spec)
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), ta)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), ta)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("validate clustertriggerauthentication when RoleArn is not empty and IdentityOwner is keda", func() {
@@ -197,9 +186,8 @@ var _ = It("validate clustertriggerauthentication when RoleArn is not empty and 
 	identityOwner := kedaString
 	spec := createTriggerAuthenticationSpecWithPodIdentity(PodIdentityProviderAws, &roleArn, nil, nil, nil, &identityOwner)
 	ta := createTriggerAuthentication("clusteridentityidta", namespaceName, "ClusterTriggerAuthentication", spec)
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), ta)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), ta)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("validate clustertriggerauthentication when RoleArn is not empty and IdentityOwner is workload", func() {
@@ -212,9 +200,8 @@ var _ = It("validate clustertriggerauthentication when RoleArn is not empty and 
 	identityOwner := workloadString
 	spec := createTriggerAuthenticationSpecWithPodIdentity(PodIdentityProviderAws, &roleArn, nil, nil, nil, &identityOwner)
 	ta := createTriggerAuthentication("clusteridentityidta", namespaceName, "ClusterTriggerAuthentication", spec)
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), ta)
-	}).Should(HaveOccurred())
+	err = k8sClient.Create(context.Background(), ta)
+	Expect(err).To(HaveOccurred())
 })
 
 var _ = It("validate clustertriggerauthentication when RoleArn is empty and IdentityOwner is keda", func() {
@@ -226,9 +213,8 @@ var _ = It("validate clustertriggerauthentication when RoleArn is empty and Iden
 	identityOwner := kedaString
 	spec := createTriggerAuthenticationSpecWithPodIdentity(PodIdentityProviderAws, nil, nil, nil, nil, &identityOwner)
 	ta := createTriggerAuthentication("clusteridentityidta", namespaceName, "ClusterTriggerAuthentication", spec)
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), ta)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), ta)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = It("validate clustertriggerauthentication when RoleArn is not empty and IdentityOwner is workload", func() {
@@ -240,9 +226,8 @@ var _ = It("validate clustertriggerauthentication when RoleArn is not empty and 
 	identityOwner := workloadString
 	spec := createTriggerAuthenticationSpecWithPodIdentity(PodIdentityProviderAws, nil, nil, nil, nil, &identityOwner)
 	ta := createTriggerAuthentication("clusteridentityidta", namespaceName, "TriggerAuthentication", spec)
-	Eventually(func() error {
-		return k8sClient.Create(context.Background(), ta)
-	}).ShouldNot(HaveOccurred())
+	err = k8sClient.Create(context.Background(), ta)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 func createTriggerAuthenticationSpecWithPodIdentity(provider PodIdentityProvider, roleArn, identityID, identityTenantID, identityAuthorityHost, identityOwner *string) TriggerAuthenticationSpec {

--- a/config/crd/bases/eventing.keda.sh_clustercloudeventsources.yaml
+++ b/config/crd/bases/eventing.keda.sh_clustercloudeventsources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: clustercloudeventsources.eventing.keda.sh
 spec:
   group: eventing.keda.sh

--- a/controllers/keda/scaledobject_controller_test.go
+++ b/controllers/keda/scaledobject_controller_test.go
@@ -722,9 +722,8 @@ var _ = Describe("ScaledObjectController", func() {
 		)
 
 		// Create the scaling target.
-		Eventually(func() error {
-			return k8sClient.Create(context.Background(), generateDeployment(deploymentName))
-		}).ShouldNot(HaveOccurred())
+		err := k8sClient.Create(context.Background(), generateDeployment(deploymentName))
+		Expect(err).ToNot(HaveOccurred())
 
 		so := &kedav1alpha1.ScaledObject{
 			ObjectMeta: metav1.ObjectMeta{Name: soName, Namespace: "default"},
@@ -751,9 +750,8 @@ var _ = Describe("ScaledObjectController", func() {
 				},
 			},
 		}
-		Eventually(func() error {
-			return k8sClient.Create(context.Background(), so)
-		}).ShouldNot(HaveOccurred())
+		err = k8sClient.Create(context.Background(), so)
+		Expect(err).ToNot(HaveOccurred())
 
 		// wait so's ready condition Ready
 		Eventually(func() metav1.ConditionStatus {
@@ -801,9 +799,8 @@ var _ = Describe("ScaledObjectController", func() {
 				},
 			},
 		}
-		Eventually(func() error {
-			return k8sClient.Status().Update(ctx, hpa)
-		}).ShouldNot(HaveOccurred())
+		err = k8sClient.Status().Update(ctx, hpa)
+		Expect(err).ToNot(HaveOccurred())
 
 		// hpa metrics will only left CPU metric
 		Eventually(func() int {


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

## Description

As discovered in https://github.com/kedacore/keda/pull/5962#issuecomment-2227553454, the `Eventually` function of Gomega is meant to `block when called and attempts an assertion periodically until it passes or a timeout occurs` ([docs](https://pkg.go.dev/github.com/onsi/gomega#Eventually)).

This means we should be using it with polling functions such as `Get` to wait for an event to happen ([example](https://github.com/kedacore/keda/blob/main/controllers/keda/scaledobject_controller_test.go#L268-L270)), but not functions such as `Create` unless we're intending to repeatedly try the creation until something different happens.

Our incorrect usage causes the existing tests to report false results, because in cases such as:

```
	Eventually(func() error {
		return k8sClient.Create(context.Background(), so)
	}).Should(HaveOccurred())
```

An error _does_ occur here, but that's caused by the error `resourceVersion should not be set on objects to be created` since `so` gets modified in-place after the first create and we're trying to apply it again.

On the other hand, if we expect no error to occur with the create:

```
	Eventually(func() error {
		return k8sClient.Create(context.Background(), so)
	}).ShouldNot(HaveOccurred())
```

If the first `Create` passes, then the Eventually block also passes. In this case, there's no point having the `Eventually` since we're not waiting for anything.

## Changes

As proof that this `Eventually` is not necessary and will only lead to false positives, I've tried removing the wrapper from all places where it's called with a mutating `Create` or `Update` call. With this change, the tests still pass.

## Checklist

- [ ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [ ] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
